### PR TITLE
Cico parser improvements

### DIFF
--- a/XenonResurrection/Parser/CicParser2021/cinstructions.h
+++ b/XenonResurrection/Parser/CicParser2021/cinstructions.h
@@ -808,6 +808,7 @@ public:
 		case CIConditionalJump::jz: m_strCondition = "!($a & $b)"; break;
 		case CIConditionalJump::jnz: m_strCondition = "$a & $b"; break;
         case CIConditionalJump::jns:
+        case CIConditionalJump::jge:
             if (pTest->m_op1.ToC() == pTest->m_op2.ToC())
             {
                 string sign = "_FIXME_";
@@ -824,6 +825,7 @@ public:
             _ASSERT(0);
             break;
         case CIConditionalJump::js:
+        case CIConditionalJump::jl:
             if (pTest->m_op1.ToC() == pTest->m_op2.ToC())
             {
                 string sign = "_FIXME_";

--- a/XenonResurrection/Parser/CicParser2021/matchers.h
+++ b/XenonResurrection/Parser/CicParser2021/matchers.h
@@ -49,6 +49,16 @@ class CIMLabel : public CInstructionMatcher
 		{
 			return make_shared<CILabel>(arrMatches[0]);
 		}
+        
+        if ( CUtils::match("^(_[\\w]*):$", strLine, arrMatches) )
+        {
+            return make_shared<CILabel>(arrMatches[0]);
+        }
+        
+        if ( CUtils::match("^([\\w]*_):$", strLine, arrMatches) )
+        {
+            return make_shared<CILabel>(arrMatches[0]);
+        }
 
 		return nullptr;
 	}


### PR DESCRIPTION
This PR basically does 2 things:

- Improve recognition of `labels`, as `__FInitRtns`, `int86_` or `_Not_Enough_Memory_`
- Add `JGE` and `JL` instructions.  JGE behaves as JNS when both operands are equals. JL behaves  as JS when both operands are equals

